### PR TITLE
HTTPS URL fix

### DIFF
--- a/abnlookup.class.php
+++ b/abnlookup.class.php
@@ -4,8 +4,8 @@
  * extends php soap client to utilize the Australian Government ABN Lookup web service 
  * requires php 5 or greater with lib-xml enabled/compiled in Apache, see the PHP manual for further requirements info
  * 
- * @link    http://www.php.net/manual/en/book.soap.php
- * @link    http://abr.business.gov.au/Webservices.aspx
+ * @link    https://www.php.net/manual/en/book.soap.php
+ * @link    https://abr.business.gov.au/Webservices.aspx
  * 
  * @param string $guid - get a guid id by registering @ http://abr.business.gov.au/Webservices.aspx
  * 
@@ -25,7 +25,7 @@ class abnlookup extends SoapClient{
             'cache_wsdl' => WSDL_CACHE_NONE
         ); 
  
-        parent::__construct('http://abr.business.gov.au/abrxmlsearch/ABRXMLSearch.asmx?WSDL', $params);
+        parent::__construct('https://abr.business.gov.au/abrxmlsearch/ABRXMLSearch.asmx?WSDL', $params);
     }
  
     public function searchByAbn($abn, $historical = 'N'){


### PR DESCRIPTION
Queries no longer work when sent to HTTP.

"SOAP-ERROR: Parsing WSDL: Couldn 't load ..."

Changing to HTTPS resolves this issue.